### PR TITLE
Query with placeholders

### DIFF
--- a/guide/SimpleE2E.md
+++ b/guide/SimpleE2E.md
@@ -24,6 +24,7 @@ import Effect.Aff.Class (class MonadAff, liftAff)
 import Effect.Class.Console (log, logShow)
 import Selda (Col, FullQuery, Table(..), aggregate, max_, count, groupBy, insert_, leftJoin, lit, notNull, query, restrict, selectFrom, selectFrom_, showQuery, (.==), (.>))
 import Selda.Aggr (Aggr)
+import Selda.Expr (showM)
 import Selda.Table.Constraint (Auto, Default)
 ```
 ## Setup
@@ -374,16 +375,19 @@ We can either specify a value for `balance` column or leave it empty and let dat
 
 ```purescript
   hoistSelda do
-    log $ showQuery qNamesWithBalance
+    -- transform Query into (Query String, Parameters) and return only SQL as a string
+    let str m = (showM 1 m).strQuery
+
+    log $ str $ showQuery qNamesWithBalance
     query qNamesWithBalance >>= logShow
 ```
 We execute a query by calling `query` and as a result we get an array of records.
-We can also get SQL string literal from a query using `showQuery` function.
+We can also get SQL string literal from a query using the `str` helper function.
 ```purescript
-    log $ showQuery qBankAccountOwnersWithBalance
+    log $ str $ showQuery qBankAccountOwnersWithBalance
     query qBankAccountOwnersWithBalance >>= logShow
 
-    log $ showQuery qCountBankAccountOwners
+    log $ str $ showQuery qCountBankAccountOwners
     query qCountBankAccountOwners >>= logShow
 
     -- query qPersonsMaxBalance >>= logShow

--- a/spago.dhall
+++ b/spago.dhall
@@ -4,17 +4,21 @@ You can edit this file as you like.
 -}
 { name =
     "selda"
-, license = "MIT"
-, repository = "https://github.com/Kamirus/purescript-selda.git"
+, license =
+    "MIT"
+, repository =
+    "https://github.com/Kamirus/purescript-selda.git"
 , dependencies =
     [ "console"
     , "exists"
     , "heterogeneous"
+    , "lists"
     , "postgresql-client"
     , "prelude"
     , "strings"
-    , "transformers"
     , "test-unit"
+    , "transformers"
+    , "variant"
     ]
 , packages =
     ./packages.dhall

--- a/src/Selda/Col.purs
+++ b/src/Selda/Col.purs
@@ -10,14 +10,14 @@ import Data.Symbol (class IsSymbol, SProxy(..), reflectSymbol)
 import Data.Tuple (Tuple(..))
 import Heterogeneous.Folding (class FoldingWithIndex, class HFoldlWithIndex, hfoldlWithIndex)
 import Heterogeneous.Mapping (class HMap, class Mapping, hmap)
-import Selda.Expr (Expr(..), Literal(..), None(..), Some(..), showExpr)
+import Selda.Expr (Expr(..), Literal(..), None(..), Some(..), ShowM, showExpr)
 import Selda.Table (Alias, Column)
 import Type.Proxy (Proxy)
 
 newtype Col s a = Col (Expr a)
 derive instance newtypeCol ∷ Newtype (Col s a) _
 
-showCol ∷ ∀ s a. Col s a → String
+showCol ∷ ∀ s a. Col s a → ShowM
 showCol = unwrap >>> showExpr
 
 lit ∷ ∀ s a. Lit a ⇒ a → Col s a

--- a/src/Selda/Expr.purs
+++ b/src/Selda/Expr.purs
@@ -2,12 +2,18 @@ module Selda.Expr where
 
 import Prelude
 
+import Control.Monad.State (State, get, put, runState)
+import Data.Array as Array
 import Data.Exists (Exists, runExists)
 import Data.Leibniz (type (~))
+import Data.List (List, (:))
+import Data.List as List
 import Data.Maybe (Maybe)
 import Data.String (joinWith)
 import Data.String.CodeUnits (fromCharArray, toCharArray)
-import Prim.RowList (kind RowList)
+import Data.Traversable (traverse)
+import Data.Tuple (Tuple(..))
+import Foreign (Foreign)
 import Selda.Table (Column, showColumn)
 
 data Literal a
@@ -38,6 +44,7 @@ data Expr o
   | EUnOp (Exists (UnExp o))
   | EFn (Exists (Fn o))
   | EInArray (Exists (InArray o)) 
+  | EForeign Foreign
 
 data BinExp o i = BinExp (BinOp i o) (Expr i) (Expr i)
 
@@ -59,6 +66,36 @@ primPGEscape = toCharArray >>> (_ >>= escape) >>> fromCharArray
     '\\' → [c, c]
     _ → pure c
 
+-- | Keeps a list of parameters that will be passed to the backend-specific
+-- | query execution (which takes SQL query as String with placeholders $<int>
+-- | and an array with parameters that correspond to these placeholders)
+type QueryParams =
+  { invertedParams ∷ List Foreign 
+  , nextIndex ∷ Int
+  }
+
+-- | State monad for: (Query AST) → (Query String with placeholders, Parameters)
+type ShowM = State QueryParams String
+
+runShowM ∷ Int → ShowM → Tuple String QueryParams
+runShowM firstIndex m = runState m
+  { invertedParams: mempty, nextIndex: firstIndex }
+
+showM
+  ∷ Int
+  → ShowM
+  → { params ∷ Array Foreign, nextIndex ∷ Int, strQuery ∷ String }
+showM i m = { params, nextIndex, strQuery }
+  where
+    (Tuple strQuery { invertedParams, nextIndex }) = runShowM i m
+    params = Array.fromFoldable $ List.reverse invertedParams
+
+showForeign ∷ Foreign → ShowM
+showForeign x = do
+  s ← get
+  put $ s { nextIndex = 1 + s.nextIndex, invertedParams = x : s.invertedParams }
+  pure $ "$" <> show s.nextIndex
+
 showLiteral ∷ ∀ a. Literal a → String
 showLiteral = case _ of
   LBoolean b _ → show b
@@ -74,31 +111,41 @@ showBinOp = case _ of
   Gt _ → " > "
   Eq _ → " = "
 
-showExpr ∷ ∀ a. Expr a → String
+showExpr ∷ ∀ a. Expr a → ShowM
 showExpr = case _ of
-  EColumn col → showColumn col
-  ELit lit → showLiteral lit
+  EColumn col → pure $ showColumn col
+  ELit lit → pure $ showLiteral lit
   EBinOp e → runExists showBinExp e
   EUnOp e → runExists showUnExp e
   EFn fn → runExists showFn fn
   EInArray e → runExists showInArray e
+  EForeign x → showForeign x
 
-showBinExp ∷ ∀ o i. BinExp o i → String
-showBinExp (BinExp op e1 e2) = "(" <> showExpr e1 <> showBinOp op <> showExpr e2 <> ")"
+showBinExp ∷ ∀ o i. BinExp o i → ShowM
+showBinExp (BinExp op e1 e2) = do
+  s1 ← showExpr e1
+  s2 ← showExpr e2
+  pure $ "(" <> s1 <> showBinOp op <> s2 <> ")"
 
-showUnExp ∷ ∀ o i. UnExp o i → String
-showUnExp (UnExp op e) = (\s → "(" <> s <> ")") $
-  case op of 
-    IsNull _ → showExpr e <> " IS NOT NULL"
-    Not _ _ → "NOT " <> showExpr e
+showUnExp ∷ ∀ o i. UnExp o i → ShowM
+showUnExp (UnExp op e) = do
+  let
+    ret s = "(" <> s <> ")"
+    matchOp s = case op of
+      IsNull _ → s <> " IS NOT NULL"
+      Not _ _ → "NOT " <> s
+  ret <$> matchOp <$> showExpr e
 
-showFn ∷ ∀ o i. Fn o i → String
-showFn = case _ of
-  FnMax e _ → "max(" <> showExpr e <> ")"
-  FnCount e _ → "count(" <> showExpr e <> ")"
-  FnSum e _ → "sum(" <> showExpr e <> ")"
+showFn ∷ ∀ o i. Fn o i → ShowM
+showFn fn = 
+  let ret op e = (\s → op <> "(" <> s <> ")") <$> showExpr e in
+  case fn of
+    FnMax e _ → ret "max" e
+    FnCount e _ → ret "count" e
+    FnSum e _ → ret "sum" e
 
-showInArray ∷ ∀ o i. InArray o i → String
-showInArray (InArray x xs _) = "(" <> showExpr x <> " IN " <> "(" <> l <> "))"
-  where
-    l = joinWith ", " $ map showExpr xs
+showInArray ∷ ∀ o i. InArray o i → ShowM
+showInArray (InArray x xs _) = do
+  s ← showExpr x
+  ss ← traverse showExpr xs
+  pure $ "(" <> s <> " IN (" <> joinWith ", " ss <> "))"

--- a/src/Selda/PG.purs
+++ b/src/Selda/PG.purs
@@ -3,6 +3,7 @@ module Selda.PG
   , showQuery
   , showDeleteFrom
   , showUpdate
+  , litF
   ) where
 
 import Prelude
@@ -11,9 +12,11 @@ import Data.Array as Array
 import Data.Exists (runExists)
 import Data.Newtype (unwrap)
 import Data.String (joinWith)
+import Data.Traversable (traverse)
 import Data.Tuple (Tuple(..))
-import Selda.Col (class GetCols, Col, getCols, showCol)
-import Selda.Expr (showExpr)
+import Database.PostgreSQL (class ToSQLValue, toSQLValue)
+import Selda.Col (class GetCols, Col(..), getCols, showCol)
+import Selda.Expr (Expr(..), ShowM, showExpr)
 import Selda.PG.ShowQuery (showState)
 import Selda.PG.Utils (class RowListLength, class TableToColsWithoutAlias, rowListLength, tableToColsWithoutAlias)
 import Selda.Query.Type (FullQuery, runQuery)
@@ -21,6 +24,9 @@ import Selda.Table (class TableColumnNames, Table(..), tableColumnNames)
 import Selda.Table.Constraint (class CanInsertColumnsIntoTable)
 import Type.Data.RowList (RLProxy)
 import Type.Proxy (Proxy(..))
+
+litF ∷ ∀ s a. ToSQLValue a ⇒ a → Col s a
+litF = Col <<< EForeign <<< toSQLValue
 
 showInsert1
   ∷ ∀ t insRLcols retRLcols
@@ -41,7 +47,7 @@ showInsert1 (Table { name }) colsToinsert colsToRet =
     <> "VALUES " <> "(" <> placeholders <> ") "
     <> "RETURNING " <> rets
 
-showQuery ∷ ∀ i s. GetCols i ⇒ FullQuery s (Record i) → String
+showQuery ∷ ∀ i s. GetCols i ⇒ FullQuery s (Record i) → ShowM
 showQuery q = showState st
   where
     (Tuple res st') = runQuery $ unwrap q
@@ -50,24 +56,23 @@ showQuery q = showState st
 showDeleteFrom
   ∷ ∀ r s r'
   . TableToColsWithoutAlias s r r'
-  ⇒ Table r → ({ | r' } → Col s Boolean) → String
-showDeleteFrom table@(Table { name }) pred = 
-  "DELETE FROM " <> name <> " WHERE " <> pred_str
-    where
-      recordWithCols = tableToColsWithoutAlias (Proxy ∷ Proxy s) table
-      pred_str = showCol $ pred recordWithCols
+  ⇒ Table r → ({ | r' } → Col s Boolean) → ShowM
+showDeleteFrom table@(Table { name }) pred = do
+  let recordWithCols = tableToColsWithoutAlias (Proxy ∷ Proxy s) table
+  pred_str ← showCol $ pred recordWithCols
+  pure $ "DELETE FROM " <> name <> " WHERE " <> pred_str
 
 showUpdate
   ∷ ∀ r s r'
   . TableToColsWithoutAlias s r r'
   ⇒ GetCols r'
-  ⇒ Table r → ({ | r' } → Col s Boolean) → ({ | r' } → { | r' }) → String
-showUpdate table@(Table { name }) pred up =
-  "UPDATE " <> name <> " SET " <> vals <> " WHERE " <> pred_str
-    where
-      recordWithCols = tableToColsWithoutAlias (Proxy ∷ Proxy s) table
-      pred_str = showCol $ pred recordWithCols
-      vals =
-        getCols (up recordWithCols)
-          # map (\(Tuple n e) → n <> " = " <> runExists showExpr e)
-          # joinWith ", "
+  ⇒ Table r → ({ | r' } → Col s Boolean) → ({ | r' } → { | r' }) → ShowM
+showUpdate table@(Table { name }) pred up = do
+  let
+    recordWithCols = tableToColsWithoutAlias (Proxy ∷ Proxy s) table
+    f (Tuple n e) = do 
+      s ← runExists showExpr e
+      pure $ n <> " = " <> s 
+  pred_str ← showCol $ pred recordWithCols
+  vals ← joinWith ", " <$> (traverse f $ getCols $ up recordWithCols)
+  pure $ "UPDATE " <> name <> " SET " <> vals <> " WHERE " <> pred_str

--- a/src/Selda/PG/ShowQuery.purs
+++ b/src/Selda/PG/ShowQuery.purs
@@ -2,54 +2,77 @@ module Selda.PG.ShowQuery where
 
 import Prelude
 
-import Data.Array (foldl, reverse)
+import Data.Array (reverse)
 import Data.Array as Array
 import Data.Exists (Exists, runExists)
+import Data.Foldable (foldM)
 import Data.Maybe (Maybe(..))
 import Data.String (joinWith)
+import Data.Traversable (traverse)
 import Data.Tuple (Tuple(..))
-import Selda.Expr (Expr, showExpr)
+import Selda.Expr (Expr, ShowM, showExpr)
 import Selda.Query.Type (GenState, Order(..), SQL(..), Source(..))
 import Selda.Table (Alias)
 
-showState ∷ GenState → String
+showState ∷ GenState → ShowM
 showState { cols, sources, restricts, aggr, order, limit } = 
+  let appendM a b = (<>) <$> a <*> b in
   showCols cols
-    <> showSources sources
-    <> showRestricts restricts
-    <> showGrouping aggr
-    <> showOrdering order
-    <> showLimit limit
+    `appendM` showSources sources
+    `appendM` showRestricts restricts
+    `appendM` showGrouping aggr
+    `appendM` showOrdering order
+    `appendM` (showLimit >>> pure) limit
 
-showCols ∷ Array (Tuple Alias (Exists Expr)) → String
-showCols = case _ of
-  [] → ""
-  xs → "SELECT " <> (joinWith ", " $ map showAliasedCol xs)
-
-showSources ∷ Array Source → String
+showSources ∷ Array Source → ShowM
 showSources sources = case Array.uncons $ reverse sources of
-  Nothing → ""
-  Just { head, tail } → " FROM "
-    <> foldl (\acc x → acc <> sepFor x <> showSource x) (showSource head) tail
+  Nothing → pure ""
+  Just { head, tail } → do 
+    let
+      f acc x = do
+        src ← showSource x
+        pure $ acc <> sepFor x <> src
+    h ← showSource head
+    (<>) " FROM " <$> foldM f h tail
 
-showRestricts ∷ Array (Expr Boolean) → String
-showRestricts = case _ of
-  [] → ""
-  xs → " WHERE " <> (joinWith " AND " $ map showExpr xs)
+showSource ∷ Source → ShowM
+showSource = case _ of
+  Product t → showSQL t
+  LeftJoin t e → do
+    sql ← showSQL t
+    exp ← showExpr e
+    pure $ sql <> " ON (" <> exp <> ")"
 
-showGrouping ∷ Array (Exists Expr) → String
-showGrouping = case _ of
-  [] → ""
-  xs → " GROUP BY " <> (joinWith ", " $ map (runExists showExpr) xs)
+showSQL ∷ SQL → ShowM
+showSQL = case _ of
+  FromTable t → pure $ t.name <> " " <> t.alias
+  SubQuery alias state → do
+    s ← showState state
+    pure $ "(" <> s <> ") " <> alias
 
-showOrdering ∷ Array (Tuple Order (Exists Expr)) → String
-showOrdering = case _ of
-  [] → ""
-  xs → " ORDER BY " <> (joinWith ", " $ map showOrder xs)
+showXS ∷ ∀ a m. Monad m ⇒ String → String → (a → m String) → Array a → m String
+showXS clause sep f = case _ of
+  [] → pure ""
+  xs → do
+    ss ← traverse f xs
+    pure $ clause <> joinWith sep ss
 
-showOrder ∷ Tuple Order (Exists Expr) → String
-showOrder (Tuple order e) =
-  runExists showExpr e <> " "
+showCols ∷ Array (Tuple Alias (Exists Expr)) → ShowM
+showCols = showXS "SELECT " ", " showAliasedCol
+
+showRestricts ∷ Array (Expr Boolean) → ShowM
+showRestricts = showXS " WHERE " " AND " showExpr
+
+showGrouping ∷ Array (Exists Expr) → ShowM
+showGrouping = showXS " GROUP BY " ", " $ runExists showExpr
+
+showOrdering ∷ Array (Tuple Order (Exists Expr)) → ShowM
+showOrdering = showXS " ORDER BY " ", " showOrder
+
+showOrder ∷ Tuple Order (Exists Expr) → ShowM
+showOrder (Tuple order e) = do
+  s ← runExists showExpr e
+  pure $ s <> " "
     <> case order of
       Asc → "ASC"
       Desc → "DESC"
@@ -59,22 +82,12 @@ showLimit = case _ of
   Nothing → ""
   Just i → " LIMIT " <> (show $ max 0 i)
 
-showSQL ∷ SQL → String
-showSQL = case _ of
-  FromTable t →
-    t.name <> " " <> t.alias
-  SubQuery alias state → 
-    "(" <> showState state <> ") " <> alias
-
 sepFor ∷ Source → String
 sepFor = case _ of
   Product _ → ", "
   LeftJoin _ _ → " LEFT JOIN "
 
-showSource ∷ Source → String
-showSource = case _ of
-  Product t → showSQL t
-  LeftJoin t e → showSQL t <> " ON (" <> showExpr e <> ")"
-
-showAliasedCol ∷ Tuple Alias (Exists Expr) → String
-showAliasedCol (Tuple alias ee) = runExists showExpr ee <> " AS " <> alias
+showAliasedCol ∷ Tuple Alias (Exists Expr) → ShowM
+showAliasedCol (Tuple alias ee) = do
+  s ← runExists showExpr ee
+  pure $ s <> " AS " <> alias


### PR DESCRIPTION
 closes #23

AST for expressions extended with `Foreign` which is meant to be passed as a parameter to the function that executes a query and in the resulting SQL string it is referenced by a placeholder (backend-specific, e.g. for postgres: `$1`)

For now the parameters where used only in the **insert** operations.
So as long as there was an appropriate `ToSQLValue` instance (from the pgclient) one could insert it without problems.
But to use **update** one needed to serialize it to string and use `Any` constructor for `Expr` AST.
Now it can use `ToSQLValue` instance to create `Foreign` and pass it into the query using `litF` function

```purescript
litF ∷ ∀ s a. ToSQLValue a ⇒ a → Col s a
```

#### Example from test suite:
```purescript
update employees                              -- UPDATE employees
  (\r → r.name .== lit "E3")                  -- WHERE name = "E3"
  (\r → r { date = litF $ date 2000 12 22 })  -- SET date = $1
                                              -- (where $1 is a placeholder)
```