### PR TITLE
Fix: Update: set only changed columns

### DIFF
--- a/src/Selda/Lit.purs
+++ b/src/Selda/Lit.purs
@@ -28,10 +28,7 @@ class Lit ∷ ∀ k. k → Type → Constraint
 class Lit s a where
   litImpl ∷ a → Col s a
 
-instance litInner ∷ Lit s a ⇒ Lit (Inner s) a where
-  litImpl a = case (litImpl a ∷ Col s a) of Col e → Col e
-
-else instance litBoolean ∷ Lit b Boolean where
+instance litBoolean ∷ Lit b Boolean where
   litImpl x = Col $ ELit $ LBoolean x identity
 
 else instance litString ∷ Lit b String where
@@ -53,3 +50,6 @@ else instance ilitPG ∷ ToSQLValue a ⇒ Lit BackendPGClass a where
 
 else instance ilitSQLite3 ∷ WriteForeign a ⇒ Lit BackendSQLite3Class a where
   litImpl = litSQLite3
+
+else instance litInner ∷ Lit s a ⇒ Lit (Inner s) a where
+  litImpl a = case (litImpl a ∷ Col s a) of Col e → Col e

--- a/src/Selda/PG.purs
+++ b/src/Selda/PG.purs
@@ -21,6 +21,11 @@ import Selda.Table.Constraint (class CanInsertColumnsIntoTable)
 litPG ∷ ∀ col s a. ToSQLValue a ⇒ Coerce col ⇒ a → col s a
 litPG = unsafeFromCol <<< Col <<< EForeign <<< toSQLValue
 
+showPGQuery
+  ∷ ShowM
+  → String
+showPGQuery = showPG >>> _.strQuery
+
 showPG
   ∷ ShowM
   → { params ∷ Array Foreign, nextIndex ∷ Int, strQuery ∷ String }

--- a/src/Selda/Query/ShowStatement.purs
+++ b/src/Selda/Query/ShowStatement.purs
@@ -47,11 +47,12 @@ showUpdate
 showUpdate table pred up = do
   let
     recordWithCols = tableToColsWithoutAlias (Proxy ∷ Proxy s) table
-    f (Tuple n e) = do 
-      s ← runExists showExpr e
-      pure $ if n == s
+    f (Tuple name expr) = do
+      updatedValue ← runExists showExpr expr
+      let columnName = showColumnName name
+      pure $ if columnName == updatedValue
         then Nothing
-        else Just $ showColumnName n <> " = " <> s 
+        else Just $ columnName <> " = " <> updatedValue 
   pred_str ← showCol $ pred recordWithCols
   vals ← joinWith ", " <$> catMaybes <$> (traverse f $ getCols $ up recordWithCols)
   pure $ if vals == "" then "" else

--- a/src/Selda/SQLite3.purs
+++ b/src/Selda/SQLite3.purs
@@ -15,6 +15,11 @@ import Simple.JSON (class WriteForeign, write)
 litSQLite3 ∷ ∀ col s a. WriteForeign a ⇒ Coerce col ⇒ a → col s a
 litSQLite3 = unsafeFromCol <<< Col <<< EForeign <<< write
 
+showSQLite3Query
+  ∷ ShowM
+  → String
+showSQLite3Query = showSQLite3 >>> _.strQuery
+
 showSQLite3
   ∷ ShowM
   → { params ∷ Array Foreign, nextIndex ∷ Int, strQuery ∷ String }


### PR DESCRIPTION
fixes #42

- test UPDATE with a `GENERATED ALWAYS AS IDENTITY` column that is not updated
- new utility functions: `showPGQuery` and `showSQLite3Query` to improve type directed search for `ShowM`
- `Lit` type class instance chain change: resolve basic types (`String`, `Int` ...) first.